### PR TITLE
Add an option dont-post-if-no-changed-files-in-report. If this is set…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ If included, will be added as a title for the comment produced.
 ##### `max-uncovered-lines` (**Optional**)
 If included, will limit the number of uncovered lines displayed in the Uncovered Lines column.
 
+##### `dont-post-if-no-changed-files-in-report` (**Optional**)
+If included, will skip posting a coverage report if no changed files would be included in the report
+
 ## Example usage
 
 ```yml

--- a/src/comment.js
+++ b/src/comment.js
@@ -4,6 +4,10 @@ import { percentage } from "./lcov"
 import { tabulate } from "./tabulate"
 
 export function comment(lcov, options) {
+	const reportTable = tabulate(lcov, options)
+	if (options.dontPostIfNoChangedFilesInReport && !reportTable) {
+		return
+	}
 	return fragment(
 		options.title ? h2(options.title) : "",
 		options.base
@@ -19,7 +23,7 @@ export function comment(lcov, options) {
 					? "Coverage Report for Changed Files"
 					: "Coverage Report",
 			),
-			tabulate(lcov, options),
+			reportTable,
 		),
 	)
 }
@@ -34,6 +38,11 @@ export function diff(lcov, before, options) {
 	const pdiff = pafter - pbefore
 	const plus = pdiff > 0 ? "+" : ""
 	const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴"
+
+	const reportTable = tabulate(lcov, options)
+	if (options.dontPostIfNoChangedFilesInReport && !reportTable) {
+		return
+	}
 
 	return fragment(
 		options.title ? h2(options.title) : "",
@@ -57,7 +66,7 @@ export function diff(lcov, before, options) {
 					? "Coverage Report for Changed Files"
 					: "Coverage Report",
 			),
-			tabulate(lcov, options),
+			reportTable,
 		),
 	)
 }

--- a/src/tabulate.js
+++ b/src/tabulate.js
@@ -30,7 +30,9 @@ export function tabulate(lcov, options) {
 			],
 			[],
 		)
-
+	if (rows.length === 0) {
+		return ""
+	}
 	return table(tbody(head, ...rows))
 }
 

--- a/src/tabulate_test.js
+++ b/src/tabulate_test.js
@@ -367,6 +367,131 @@ test("filtered tabulate should generate a correct table with only changed files"
 	expect(tabulate(data, options)).toBe(html)
 })
 
+test("filtered tabulate should generate an empty result when no matching changed files and dontPostIfNoChangedFilesInReport set", function() {
+	const data = [
+		{
+			file: "/files/project/index.js",
+			functions: {
+				found: 0,
+				hit: 0,
+				details: [],
+			},
+		},
+		{
+			file: "/files/project/src/foo.js",
+			lines: {
+				found: 23,
+				hit: 21,
+				details: [
+					{
+						line: 20,
+						hit: 3,
+					},
+					{
+						line: 21,
+						hit: 3,
+					},
+					{
+						line: 22,
+						hit: 3,
+					},
+				],
+			},
+			functions: {
+				hit: 2,
+				found: 3,
+				details: [
+					{
+						name: "foo",
+						line: 19,
+					},
+					{
+						name: "bar",
+						line: 33,
+					},
+					{
+						name: "baz",
+						line: 54,
+					},
+				],
+			},
+			branches: {
+				hit: 3,
+				found: 3,
+				details: [
+					{
+						line: 21,
+						block: 0,
+						branch: 0,
+						taken: 1,
+					},
+					{
+						line: 21,
+						block: 0,
+						branch: 1,
+						taken: 2,
+					},
+					{
+						line: 37,
+						block: 1,
+						branch: 0,
+						taken: 0,
+					},
+				],
+			},
+		},
+		{
+			file: "/files/project/src/bar/baz.js",
+			lines: {
+				found: 10,
+				hit: 5,
+				details: [
+					{
+						line: 20,
+						hit: 0,
+					},
+					{
+						line: 21,
+						hit: 0,
+					},
+					{
+						line: 27,
+						hit: 0,
+					},
+				],
+			},
+			functions: {
+				hit: 2,
+				found: 3,
+				details: [
+					{
+						name: "foo",
+						line: 19,
+					},
+					{
+						name: "bar",
+						line: 33,
+					},
+					{
+						name: "baz",
+						line: 54,
+					},
+				],
+			},
+		},
+	]
+
+	const options = {
+		repository: "example/foo",
+		commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
+		prefix: "/files/project/",
+		shouldFilterChangedFiles: true,
+		changedFiles: ["src/not-in-this-report.js"],
+	}
+
+	expect(tabulate(data, options)).toBe("")
+})
+
 test("filtered tabulate should fix backwards slashes in filenames", function() {
 	const data = [
 		{


### PR DESCRIPTION
… to true, and no changed files for the PR would be included in the report, then skip posting.
Also, if this option is not set, the table will be an empty string, rather than an empty table when no changed files in the report.