### PR TITLE
Update runtime to node20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: mskelton/setup-yarn@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Build and run tests
         run: |

--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ inputs:
     description: If included, will fail if coverage drops more than the given percentage
     required: false
 runs:
-  using: node16
+  using: node20
   main: dist/main.js


### PR DESCRIPTION
Node 16 is deprecated and workflows should be updated to use Node 20 instead, based on this https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/